### PR TITLE
Security Patches :D

### DIFF
--- a/adb/client/file_sync_client.cpp
+++ b/adb/client/file_sync_client.cpp
@@ -477,6 +477,17 @@ class SyncConnection {
             if (!ReadFdExactly(fd, buf, len)) return false;
             buf[len] = 0;
 
+            // Address the unlikely scenario wherein a
+            // compromised device/service might be able to
+            // traverse across directories on the host. Let's
+            // shut that door!
+            if (strchr(buf, '/')
+#if defined(_WIN32)
+                || strchr(buf, '\\')
+#endif
+            ) {
+                return false;
+            }
             callback(dent.mode, dent.size, dent.mtime, buf);
         }
     }


### PR DESCRIPTION
Backport of Win-specific suppression of potentially rogue construct that can engage

in directory traversal on the host.

Bug:209438553

Ignore-AOSP-First: Resolution for potential security exploit.

Test: Cursory test with adb.

Change-Id: Id47c567ad92ae4d9d7325a7a8589825a2ff4232b Merged-In: Ie1f82db2fb14e1bdd183bf8d3d93d5e9f974be5d (cherry picked from commit c3483e4c8a302e7852e0a334ffa90089337520ec) Merged-In: Id47c567ad92ae4d9d7325a7a8589825a2ff4232b